### PR TITLE
add auto orient, auto fit, and standard page sizes

### DIFF
--- a/src/img2pdf.py
+++ b/src/img2pdf.py
@@ -20,7 +20,7 @@
 import sys
 import zlib
 import argparse
-import struct
+
 from PIL import Image
 from datetime import datetime
 from jp2 import parsejp2


### PR DESCRIPTION
Added auto orient, auto fit, and standard page size recognition to --pagesize option.

Auto orient will ensure that the output page orientation matches the input orientation so that, for instance, landscape images are not distorted into a portrait page.  This option is activated by appending a '+' to the output dimensions.

Auto fit will resize an image within specified boundaries while retaining the aspect ratio.  This option is activated by appending a '^' to the output dimensions.

Recognized page sizes include: letter, tabloid, ledger, legal, statement, executive, a0 - a5, folio, and quarto.