### PR TITLE
Add check for empty list

### DIFF
--- a/src/img2pdf.py
+++ b/src/img2pdf.py
@@ -1991,6 +1991,9 @@ def convert(*images, **kwargs):
 
     if not isinstance(images, (list, tuple)):
         images = [images]
+    else:
+        if len(images) == 0:
+            raise ValueError("Unable to process empty list")
 
     for img in images:
         # img is allowed to be a path, a binary string representing image data


### PR DESCRIPTION
Adds a check for the convert when an empty list is given

This covers the case: img2pdf.convert([])

Currently runs and gives an index error in the tostream() function at line 1047-1049:
        # by default the initial page is the first one
        if self.engine == Engine.pikepdf:
            initial_page = self.writer.pages[0]

I wanted to add a test case, but I don't really understand the structure of the test file