### PR TITLE
for some JPEG files PIL does not return DPI, but returns jfif_density

### DIFF
--- a/src/img2pdf.py
+++ b/src/img2pdf.py
@@ -1313,9 +1313,18 @@ def get_imgmetadata(
 
         ndpi = imgdata.info.get("dpi")
         if ndpi is None:
+            # See: https://github.com/python-pillow/Pillow/issues/8632
+            if imgformat == ImageFormat.JPEG and imgdata.info.get("jfif_density") is not None:
+                jfif_density = imgdata.info.get("jfif_density")
+                jfif_unit = imgdata.info.get("jfif_unit", 0)
+                if jfif_unit == 1:
+                    ndpi = jfif_density
+                elif jfif_unit == 2:
+                    ndpi = (jfif_density[0] * 2.54, jfif_density[1] * 2.54)
+
             # the PNG plugin of PIL adds the undocumented "aspect" field instead of
             # the "dpi" field if the PNG pHYs chunk unit is not set to meters
-            if imgformat == ImageFormat.PNG and imgdata.info.get("aspect") is not None:
+            elif imgformat == ImageFormat.PNG and imgdata.info.get("aspect") is not None:
                 aspect = imgdata.info["aspect"]
                 # make sure not to go below the default dpi
                 if aspect[0] > aspect[1]:


### PR DESCRIPTION
For some JPEG files - for instance some produced by imagemagick - PIL does not return correct DPI, even though DPI is there, in files' headers. For such files img2pdf does not get their PDF, so it assumes it is 96. It causes that when generated PDF is displayed on a screen, pages' sizes are wrong.

To reproduce the problem, generate PDF from  
([these two JPEG files](https://github.com/user-attachments/files/18265507/pages.zip)). When I do it with command:

```
$ python3 src/img2pdf.py page-1.jpg page-2.jpg -o output.pdf
```

it produces [a PDF file](https://github.com/user-attachments/files/18265512/output.pdf) with two pages and when the PDF is displayed on a screen, the sizes of the pages are different. Which is wrong: the dimensions of the two files measured in pixels are different, but they have different DPI, so their dimensions measured in centimeters should be the same.

I already [reported a problem to Pillow](https://github.com/python-pillow/Pillow/issues/8632), but until they fix it, the change in this pull request fixes the problem.