### PR TITLE
Add macOS ICC profile path support

### DIFF
--- a/src/img2pdf.py
+++ b/src/img2pdf.py
@@ -4148,6 +4148,9 @@ def get_default_icc_profile():
         "/usr/share/color/icc/sRGB.icc",
         "/usr/share/color/icc/OpenICC/sRGB.icc",
         "/usr/share/color/icc/colord/sRGB.icc",
+
+        # macOS
+        "/System/Library/ColorSync/Profiles/sRGB Profile.icc",
     ]:
         if not os.path.exists(profile):
             continue


### PR DESCRIPTION
Add the standard macOS ICC profile location (`/System/Library/ColorSync/Profiles/sRGB Profile.icc`) to the default sRGB profile lookup path in `get_default_icc_profile()`.

This enables img2pdf to find the system's sRGB color profile on macOS systems without requiring manual configuration.

**Changes:**
- Extended the profile path list in `get_default_icc_profile()` to include the macOS standard sRGB profile location

**Testing:**
- Function executes without errors
- Module imports successfully
- Code syntax is valid